### PR TITLE
Remove unwanted </ul> tag close on configuration documentation

### DIFF
--- a/_docs/configuring.md
+++ b/_docs/configuring.md
@@ -118,7 +118,6 @@ curl -X DELETE "http://localhost:8080/user/johndoe"
   Some APIs may have changed starting from Dicoogle 3.0.0.
   For instance, creating new users was done with the PUT method instead of POST.
   Be sure to update all integration software when migrating.
-  </ul>
 </div>
 
 ------------------


### PR DESCRIPTION
<img width="1698" alt="image" src="https://github.com/bioinformatics-ua/dicoogle-learning-pack/assets/21096850/35464f4d-1ff2-4a3b-bd30-4d332f6a1f16">


This PR will merge the unwanted ul tag in configuration docs