### PR TITLE
Add Dockerfile and docker-compose.yml for building documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,25 @@
+FROM ruby:3.2.3
+
+# Install dependencies
+RUN apt-get update -qq && apt-get install -y \
+    build-essential \
+    nodejs
+
+# Set working directory
+WORKDIR /app
+
+# Copy Gemfile and Gemfile.lock
+COPY Gemfile Gemfile.lock ./
+
+# Install gems
+RUN gem install jekyll bundler
+RUN bundle install
+
+# Copy the website source code
+COPY . .
+
+# Expose port 4000
+EXPOSE 4000
+
+# Default command to run
+CMD ["bundle", "exec", "jekyll", "serve", "--host", "0.0.0.0"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,8 @@
+version: "3.9"
+services:
+  dicoogle-learning-pack:
+    build: .
+    ports:
+      - "4000:4000"
+    volumes:
+      - ./:/app # Mount the current directory to the container's /app directory


### PR DESCRIPTION
This pull request adds a `Dockerfile` and `docker-compose.yml` to streamline the process of building the Dicoogle Learning Pack documentation.

**How to use:**

1.  Navigate to the project directory.
2.  Run `docker-compose up -d` to build and start the documentation website.
3.  Access the website at `http://localhost:4000`.

This enhancement aims to improve the developer experience and make it easier to build and maintain the Dicoogle Learning Pack documentation.